### PR TITLE
Fix onChange handler so it produces a value

### DIFF
--- a/src/Pux/DOM/HTML/Attributes.purs
+++ b/src/Pux/DOM/HTML/Attributes.purs
@@ -42,6 +42,13 @@ type KeyboardEvent =
   , which    :: Int
   }
 
+type Target = { value :: String }
+
+type ChangeEvent =
+  {
+    target :: Target
+  }
+
 -- | ```purescript
 -- | button ! onClick (send Increment)
 -- | ```
@@ -84,8 +91,8 @@ onFocus (Handler actions fx) = makeHandler "onFocus" fx $ \ev -> actions
 onBlur :: forall action eff. Handler KeyboardEvent (KeyboardEvent -> action) (dom :: DOM, channel :: CHANNEL | eff) -> Attrs
 onBlur (Handler actions fx) = makeHandler "onBlur" fx $ \ev -> actions
 
-onChange :: forall action eff. Handler KeyboardEvent (KeyboardEvent -> action) (dom :: DOM, channel :: CHANNEL | eff) -> Attrs
-onChange (Handler actions fx) = makeHandler "onChange" fx $ \ev -> actions
+onChange :: forall action eff. Handler ChangeEvent (ChangeEvent -> action) (dom :: DOM, channel :: CHANNEL | eff) -> Attrs
+onChange (Handler actions fx) = makeHandler "onChange" fx $ \ev -> map (\a -> a ev) actions
 
 onInput :: forall action eff. Handler KeyboardEvent (KeyboardEvent -> action) (dom :: DOM, channel :: CHANNEL | eff) -> Attrs
 onInput (Handler actions fx) = makeHandler "onInput" fx $ \ev -> actions


### PR DESCRIPTION
- uses more correct event type - so it produces a value
- event data was now passed to the handler, before it would render a pattern match
  failure in state

Working demonstration of this patch -

https://github.com/mostalive/purescript-pux-textinput-demo

Didn't know how to provide better feedback. The repo above contains a
copy of this patch, so it was easier to try out modifications.

things to consider:
- onInput and onSubmit probably need the same event type and handling
- handle more attributes? [react forms documentation](https://facebook.github.io/react/docs/forms.html) only suggests .target.value, debug logging suggests it is a SyntheticEvent which has more parameters
  (for my use case I'm happy enough with .target.value )
