### PR TITLE
Export a type alias for the core set of Pux effects

### DIFF
--- a/src/Pux.purs
+++ b/src/Pux.purs
@@ -2,6 +2,7 @@ module Pux
   ( App
   , Update
   , EffModel
+  , CoreEffects
   , noEffects
   , fromSimple
   , start
@@ -36,7 +37,7 @@ import Signal.Channel (CHANNEL, channel, subscribe, send)
 -- | ```
 start :: forall state action eff.
          Config state action eff ->
-         Eff (err :: EXCEPTION, channel :: CHANNEL | eff) (App state action)
+         Eff (CoreEffects eff) (App state action)
 start config = do
   actionChannel <- channel Nil
   let actionSignal = subscribe actionChannel
@@ -74,6 +75,18 @@ type Config state action eff =
   , initialState :: state
   , inputs :: Array (Signal action)
   }
+
+-- | The set of effects every Pux app needs to allow through when using `start`.
+-- | Extend this type with your own app's effects, for example:
+-- |
+-- | ```purescript
+-- | type AppEffects eff = (console :: CONSOLE | eff)
+-- |
+-- | main :: State -> Eff (CoreEffects (AppEffects (dom :: DOM))) (App State Action)
+-- | main state = do
+-- |   -- ...
+-- | ```
+type CoreEffects eff = (channel :: CHANNEL, err :: EXCEPTION | eff)
 
 -- | An `App` consists of three signals:
 -- |


### PR DESCRIPTION
(For the sake of reuse and convenience.)

When an app developer writes their own app effects type alias, eg.

```
type AppEffects eff = (log :: CONSOLE | eff)
```

... This allows two things:
- `main` to have a type using `(CoreEffects (AppEffects eff))`.
- Individual `update` functions to, if the shortcut is appropriate, have _only_ `(AppEffects eff)`, to avoid the common problem where PureScript complains about getting two instances of `channel` or `exception` if an `update` function is declared with either.

(I mention only having one App effect-set above, but in reality I'd have a few finer-grained aliases.)
