### PR TITLE
Bumps purescript-signal to 5.1.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "purescript-aff": "^0.16.1",
     "purescript-eff": "^0.1.2",
     "purescript-lists": "^0.7.10",
-    "purescript-signal": "^5.0.0",
+    "purescript-signal": "^5.1.0",
     "purescript-maps": "^0.5.4",
     "purescript-functions": "^0.1.0"
   },


### PR DESCRIPTION
… Which fixes the FFI-related errors that 0.8.4 brings to light.

(`purescript-signal` 5.1.0 includes the removal of the unused `foldpP`, and an upgrade of `purescript-dom` to 0.2.20 which fixes its own FFI errors.)
