### PR TITLE
Invoke React.createElement correctly when passing it children

### DIFF
--- a/src/Pux.js
+++ b/src/Pux.js
@@ -47,8 +47,6 @@ exports.toReact = function (htmlSignal) {
 exports.fromReact = function (comp) {
   return function (attrs) {
     return function (children) {
-      if (Array.isArray(children[0])) children = children[0];
-
       var props = attrs.reduce(function (obj, attr) {
         var key = attr[0];
         var val = attr[1];
@@ -56,14 +54,14 @@ exports.fromReact = function (comp) {
         return obj;
       }, {});
 
-      return React.createElement(comp, props, children);
+      return React.createElement.apply(null, [comp, props].concat(children))
     };
   };
 };
 
 exports.render = function (input, parentAction, html) {
   if (typeof html === 'string') {
-    html = React.createElement('div', null, [html]);
+    html = React.createElement('div', null, html);
   }
 
   function composeAction(parentAction, html) {


### PR DESCRIPTION
The prototype of `React.createElements` is:

```
ReactElement createElement(
  string/ReactClass type,
  [object props],
  [children ...]
)
```

The children array is not passed in the third argument, but instead passed as varargs.

The syntax of calling functions with varargs is easier in ES2015 with the spread operator: `React.createElement(comp, props, ...children)`. In ES5, we have to use `.apply`. 

This avoids the React warning about missing keys. This warning is only generated if one of the children is an array (technically allowed, but each item therein must have a `key` prop).

In short, this generates a warning:

```
React.createElement(comp, props, [someChild, anotherChild])
```

while this does not:

```
React.createElement(comp, props, someChild, anotherChild)
```
