### PR TITLE
Update using-pux-components-in-react.md

### DIFF
--- a/docs/react-interop/using-pux-components-in-react.md
+++ b/docs/react-interop/using-pux-components-in-react.md
@@ -11,7 +11,9 @@ module Counter where
 
 import Control.Monad.Eff (Eff)
 import Prelude ((+), (-), bind, const, show)
-import Pux (CoreEffects, ReactClass)
+import Pux as Pux
+import Pux (CoreEffects)
+import React (ReactClass)
 import Pux.Html (Html, div, span, button, text)
 import Pux.Html.Events (onClick)
 
@@ -49,5 +51,5 @@ After your PureScript has been compiled, call this module's `toReact` method to
 return your class:
 
 ```javascript
-const Counter = PS.Counter.toReact(state)
+const Counter = PS.Counter.toReact(state)()
 ```


### PR DESCRIPTION
The import syntax has apparently changed in 0.9
I was getting the error `UnknownName` on `Pux.toReact`
I could add it to the explicit imports, but then I needed to change my function from `toReact` to `mkReact` or something like that to avoid a naming conflict.

ReactClass is not re-exported from Pux namespace so I needed to update this import as well.

Also it appears PS.Counter.toReact(state) returns a function not a React class, so I suggested maybe changing `const Counter = PS.Counter.toReact(state)` to `const Counter = PS.Counter.toReact(state)()`?  
I'm still very new to purescript and I'm guessing that perhaps there is a better way to do this so that toReact returns a value instead but I couldn't seem to figure it out in this context.
