### PR TITLE
fromReact should pass undefined for children when array is empty

### DIFF
--- a/src/Pux.js
+++ b/src/Pux.js
@@ -48,6 +48,7 @@ exports.fromReact = function (comp) {
   return function (attrs) {
     return function (children) {
       if (Array.isArray(children[0])) children = children[0];
+      if (Array.isArray(children) && children.length === 0) children = undefined;
 
       var props = attrs.reduce(function (obj, attr) {
         var key = attr[0];


### PR DESCRIPTION
In React JSX, if no children are defined the value of this.props.children is undefined rather than an empty array.  https://facebook.github.io/react/tips/children-undefined.html

`Pux.fromReact` however always requires a, possibly empty, Array instead.  While it would be nice if these were equivalent, unfortunately these have different truthy values in javascript.
if(undefined) returns false but if([]) returns true.... so this causes some components to break.  For example: [material-ui/TextField](https://github.com/callemall/material-ui/blob/master/src/TextField/TextField.js#L282)
