### PR TITLE
Support event.target.checked for checkbox inputs

### DIFF
--- a/src/Pux/Html/Events.purs
+++ b/src/Pux/Html/Events.purs
@@ -3,7 +3,7 @@ module Pux.Html.Events where
 import Data.Function.Uncurried (Fn2, runFn2)
 import Pux.Html (Attribute)
 
-type Target = { value :: String }
+type Target = { value :: String, checked :: Boolean }
 
 type ClipboardEvent =
   { target :: Target


### PR DESCRIPTION
Checkbox (and radio button) inputs report their value through a boolean on `event.target.checked`, and not through `event.target.value`.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement says that event.target.checked should be a boolean, and not null or undefined. I've tested that at least in chrome `event.target.checked` is always `false` for inputs of types other than checkbox or radio.
