### PR TITLE
Fix withTextChild and withChildren operators

### DIFF
--- a/src/Pux/Html.purs
+++ b/src/Pux/Html.purs
@@ -89,4 +89,4 @@ withChildren :: forall a.
              Html a
 withChildren f htmls = f [] htmls
 
-infixr 4 withChildren as ##
+infixr 0 withChildren as ##

--- a/src/Pux/Html.purs
+++ b/src/Pux/Html.purs
@@ -6,6 +6,7 @@ module Pux.Html
   , (##)
   , bind
   , withAttr
+  , withTextChild
   , withChild
   , withChildren
   ) where

--- a/src/Pux/Html.purs
+++ b/src/Pux/Html.purs
@@ -80,7 +80,7 @@ withTextChild :: forall a.
              Html a
 withTextChild f txt = f # Elements.text txt
 
-infixr 0 withChildren as #>
+infixr 0 withTextChild as #>
 
 withChildren :: forall a.
              (Array (Attribute a) -> Array (Html a) -> Html a) ->


### PR DESCRIPTION
The `withTextChild` operator had a typo and the function wasn't exported.
The `withChildren` operator had a precedence of 4 instead of 0.
