### PR TITLE
Export Match constructor to allow user-constructed matchers

### DIFF
--- a/src/Pux/Router.purs
+++ b/src/Pux/Router.purs
@@ -1,5 +1,6 @@
 module Pux.Router
-  ( Match()
+  ( Match(..)
+  , Route
   , RoutePart(..)
   , sampleUrl
   , router


### PR DESCRIPTION
First of all thank you Alex for this fantastic library.  I've submitted you this PR because I need a matcher that matches a variable number of path segments followed by a variable.  Let me know if you have a better idea for supporting this than exporting the Match constructor and I'll give it a shot.