### PR TITLE
Add  to handle events thrown by custom components.

### DIFF
--- a/src/Pux/Html/Events.purs
+++ b/src/Pux/Html/Events.purs
@@ -94,6 +94,10 @@ type MediaEvent =
   , currentTarget :: Target
   }
 
+-- Handle user-defined type of event.
+evt :: forall event action. String -> (event -> action) -> Attribute action
+evt eventName = runFn2 handler eventName
+
 onCopy :: forall action. (ClipboardEvent -> action) -> Attribute action
 onCopy = runFn2 handler "onCopy"
 


### PR DESCRIPTION
I think Pux needs an `evt` function to allow users to respond to events containing arbitrarily-shaped data, as third-party components often fire uniquely-shaped events. This is similar to the `attr` function, which already exists in this library. What do you think?

Details of my use-case follows.

I imported the [React Bootstrap Datepicker ](https://www.npmjs.com/package/react-bootstrap-date-picker) components into my project, using the `Pux.fromReact` function, and I want to respond to the `onChange` event it fires. The type of the event it throws is unlike any event defined in this repo, it is `type DatePickerSelectEvent = String`, where the String is the ISO-encoded date which was selected. 

Here's the relevant snippets from my project, which might clarify.

``` purescript
import App.ReactBootstrap.Components as RBC
...
type DatePickerSelectEvent = String
data Action = x | y | ChangeReservationDate DatePickerSelectEvent
...
update (ChangeReservationDate newDate) state = noEffects $ state { reservationDate = newDate }
...
view state =
  form [ onSubmit (ReservationViewChange) ]
    [ formGroup [ attr "controlId" "reservationDate" ]
      [ controlLabel []
        [ text "Reservation Date" ]
      , RBC.datePicker [ attr "id" "reservation-datepicker",  value state.reservationDate, evt "onChange" ChangeReservationDate ]
        []
      ]
    , ...
```