### PR TITLE
Namespace pux events to support third-party components

### DIFF
--- a/src/Pux.js
+++ b/src/Pux.js
@@ -82,7 +82,7 @@ exports.render = function (input, parentAction, html) {
     var newProps = {};
 
     for (var key in props) {
-      if (key !== 'puxParentAction' && typeof props[key] === 'function') {
+      if (key !== 'puxParentAction' && props[key].isPuxHandler) {
         newProps[key] = props[key](input, parentAction);
       }
     }

--- a/src/Pux/Html/Elements.js
+++ b/src/Pux/Html/Elements.js
@@ -37,16 +37,20 @@ exports.forwardTo = function (parentAction) {
   };
 };
 
+function puxHandler(h) {
+  h.isPuxHandler = true
+  return h;
+}
 // :: (a -> b) -> Attribute a -> Attribute b
 exports.mapAttribute = function (f) {
   return function (attr) {
     if (typeof attr[1] !== 'function') {
       return attr;
     }
-    return [attr[0], function(input, parentAction) {
+    return [attr[0], puxHandler(function(input, parentAction) {
       return attr[1](input, function(e) {
         return f(parentAction(e));
       });
-    }];
+    })];
   };
 };

--- a/src/Pux/Html/Events.js
+++ b/src/Pux/Html/Events.js
@@ -2,8 +2,13 @@
 
 // module Pux.Html.Events
 
+function puxHandler(h) {
+  h.isPuxHandler = true
+  return h;
+};
+
 exports.handler = function (key, action) {
-  return [key, function (input, parentAction) {
+  return [key, puxHandler(function (input, parentAction) {
     return function (ev) {
       if ((key === 'onSubmit')
       || (key === 'onClick' && ev.currentTarget.nodeName.toLowerCase() === 'a')) {
@@ -11,7 +16,7 @@ exports.handler = function (key, action) {
       }
       input(parentAction(action(ev)))();
     };
-  }];
+  })];
 };
 
 exports.onKeyHandler = function (keyName, action) {

--- a/src/Pux/Html/Events.js
+++ b/src/Pux/Html/Events.js
@@ -20,11 +20,11 @@ exports.handler = function (key, action) {
 };
 
 exports.onKeyHandler = function (keyName, action) {
-  return ["onKeyUp", function (input, parentAction) {
+  return ["onKeyUp", puxHandler(function (input, parentAction) {
     return function (ev) {
       if (ev.key.toLowerCase() === keyName.toLowerCase()) {
         input(parentAction(action(ev)))();
       }
     };
-  }];
+  })];
 };

--- a/src/Pux/Html/Events.purs
+++ b/src/Pux/Html/Events.purs
@@ -94,6 +94,10 @@ type MediaEvent =
   , currentTarget :: Target
   }
 
+-- Handle user-defined type of event.
+evt :: forall event action. String -> (event -> action) -> Attribute action
+evt eventName = runFn2 handler eventName
+
 onCopy :: forall action. (ClipboardEvent -> action) -> Attribute action
 onCopy = runFn2 handler "onCopy"
 

--- a/src/Pux/Router.js
+++ b/src/Pux/Router.js
@@ -18,8 +18,14 @@ exports.createUrlSignal = function locationChanged(constant) {
   };
 };
 
+
+function puxHandler(h) {
+  h.isPuxHandler = true
+  return h;
+};
+
 exports.linkHandler = function (url) {
-  return ['onClick', function (input, parentAction) {
+  return ['onClick', puxHandler(function (input, parentAction) {
     return function (ev) {
       ev.preventDefault();
       if (typeof window !== 'undefined') {
@@ -27,7 +33,7 @@ exports.linkHandler = function (url) {
         window.dispatchEvent(new Event('popstate'));
       }
     };
-  }];
+  })];
 };
 
 exports.navigateTo = function (url) {


### PR DESCRIPTION
Third-party components can't be wrapped if they have have default properties which are functions. An example of such function is a third-party component defining an `onSelect` property.

This does a better job of noting which functions are Pux-managed event handlers.

Note that this includes the https://github.com/alexmingoia/purescript-pux/pull/94 commit. Can edit this PR if desired.