### PR TITLE
Generic rendering backend targets

### DIFF
--- a/src/Pux.js
+++ b/src/Pux.js
@@ -61,42 +61,12 @@ exports.fromReact = function (comp) {
   };
 };
 
-exports.render = function (input, parentAction, html) {
-  if (typeof html === 'string') {
-    html = React.createElement('div', null, html);
-  }
+exports.wrapRender = function (render) {
+    return function(input, parentAction, html) {
+        if (typeof html === 'string') {
+            html = React.createElement('div', null, html);
+        }
 
-  function composeAction(parentAction, html) {
-    var childAction = html.props && html.props.puxParentAction;
-    var action = parentAction;
-    if (childAction) {
-      action = function (a) {
-        return parentAction(childAction(a));
-      };
+        return render(input, parentAction, html);
     }
-    return action;
-  }
-
-  function render(input, parentAction, html) {
-    var props = html.props
-    var newProps = {};
-
-    for (var key in props) {
-      if (key !== 'puxParentAction' && typeof props[key] === 'function') {
-        newProps[key] = props[key](input, parentAction);
-      }
-    }
-
-    var newChildren = React.Children.map(html.props.children, function (child) {
-      if (typeof child === 'string') {
-        return child;
-      } else {
-        return render(input, composeAction(parentAction, child), child);
-      }
-    });
-
-    return React.cloneElement(html, newProps, newChildren);
-  }
-
-  return render(input, composeAction(parentAction, html), html);
 };

--- a/src/Pux.purs
+++ b/src/Pux.purs
@@ -1,36 +1,22 @@
 module Pux
   ( App
   , Config
-  , Update
-  , EffModel
-  , CoreEffects
-  , noEffects
-  , onlyEffects
-  , fromSimple
-  , mapState
-  , mapEffects
   , renderToDOM
   , renderToString
   , start
   , toReact
+  , module Pux.Base
   ) where
 
-import Control.Monad.Aff (Aff, launchAff, later)
-import Control.Monad.Aff.Unsafe (unsafeCoerceAff)
 import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Class (liftEff)
-import Control.Monad.Eff.Exception (EXCEPTION)
-import Data.Foldable (foldl, sequence_)
-import Data.Function.Uncurried (Fn3, runFn3)
-import Data.List (List(Nil), singleton, (:), reverse, fromFoldable)
-import Data.Maybe (fromJust)
-import Partial.Unsafe (unsafePartial)
-import Prelude (Unit, ($), (<<<), map, pure)
-import Prelude as Prelude
+import Data.Function.Uncurried (Fn3)
+import Prelude (Unit, ($))
 import Pux.Html (Html)
 import React (ReactClass)
-import Signal (Signal, (~>), mergeMany, foldp, runSignal)
-import Signal.Channel (CHANNEL, Channel, channel, subscribe, send)
+import Signal (Signal)
+
+import Pux.Base (Update, EffModel, CoreEffects, fromSimple, noEffects, onlyEffects, mapState, mapEffects)
+import Pux.Base as B
 
 -- | Start an application. The resulting html signal is fed into `renderToDOM`.
 -- |
@@ -46,29 +32,12 @@ import Signal.Channel (CHANNEL, Channel, channel, subscribe, send)
 -- | ```
 start :: forall state action eff.
          Config state action eff ->
-         Eff (CoreEffects eff) (App state action)
-start config = do
-  actionChannel <- channel Nil
-  let actionSignal = subscribe actionChannel
-      input = unsafePartial $ fromJust $ mergeMany $
-        reverse (actionSignal : map (map singleton) (fromFoldable $ config.inputs))
-      foldState effModel action = config.update action effModel.state
-      foldActions actions effModel =
-        foldl foldState (noEffects effModel.state) actions
-      effModelSignal =
-        foldp foldActions (noEffects config.initialState) input
-      stateSignal = effModelSignal ~> _.state
-      htmlSignal = stateSignal ~> \state ->
-        (runFn3 render) (send actionChannel <<< singleton) (\a -> a) (config.view state)
-      mapAffect affect = launchAff $ unsafeCoerceAff do
-        action <- later affect
-        liftEff $ send actionChannel (singleton action)
-      effectsSignal = effModelSignal ~> map mapAffect <<< _.effects
-  runSignal $ effectsSignal ~> sequence_
-  pure $ { html: htmlSignal, state: stateSignal, actionChannel: actionChannel }
-  where bind = Prelude.bind
+         Eff (B.CoreEffects eff) (App state action)
+start = B.start' $ wrapRender B.render
 
-foreign import render :: forall a eff. Fn3 (a -> Eff eff Unit) (a -> a) (Html a) (Html a)
+
+foreign import wrapRender :: forall a eff target. B.Renderer Html a eff -> Fn3 (a -> Eff eff Unit) (a -> a) (target a) (target a)
+
 
 -- | The configuration of an app consists of update and view functions along
 -- | with an initial state.
@@ -78,24 +47,7 @@ foreign import render :: forall a eff. Fn3 (a -> Eff eff Unit) (a -> a) (Html a)
 -- |
 -- | The `inputs` array is for any external signals you might need. These will
 -- | be merged into the app's input signal.
-type Config state action eff =
-  { update :: Update state action eff
-  , view :: state -> Html action
-  , initialState :: state
-  , inputs :: Array (Signal action)
-  }
-
--- | The set of effects every Pux app needs to allow through when using `start`.
--- | Extend this type with your own app's effects, for example:
--- |
--- | ```purescript
--- | type AppEffects = (console :: CONSOLE, dom :: DOM)
--- |
--- | main :: State -> Eff (CoreEffects AppEffects) (App State Action)
--- | main state = do
--- |   -- ...
--- | ```
-type CoreEffects eff = (channel :: CHANNEL, err :: EXCEPTION | eff)
+type Config state action eff = B.Config Html state action eff
 
 -- | An `App` consists of three signals:
 -- |
@@ -103,43 +55,7 @@ type CoreEffects eff = (channel :: CHANNEL, err :: EXCEPTION | eff)
 -- |   app. This should be fed into `renderToDOM`.
 -- |
 -- | * `state` – A signal representing the application's current state.
-type App state action =
-  { html :: Signal (Html action)
-  , state :: Signal state
-  , actionChannel :: Channel (List action)
-  }
-
--- | Synonym for an update function that returns state and an array of
--- | asynchronous effects that return an action.
-type Update state action eff = action -> state -> EffModel state action eff
-
--- | `EffModel` is a container for state and a collection of asynchronous
--- | effects which return an action.
-type EffModel state action eff =
-  { state :: state
-  , effects :: Array (Aff (CoreEffects eff) action) }
-
--- | Create an `Update` function from a simple step function.
-fromSimple :: forall s a eff. (a -> s -> s) -> Update s a eff
-fromSimple update = \action state -> noEffects $ update action state
-
--- | Create an `EffModel` with no effects from a given state.
-noEffects :: forall state action eff. state -> EffModel state action eff
-noEffects state = { state: state, effects: [] }
-
-onlyEffects :: forall state action eff.
-               state -> Array (Aff (CoreEffects eff) action) -> EffModel state action eff
-onlyEffects state effects = { state: state, effects: effects }
-
--- | Map over the state of an `EffModel`.
-mapState :: forall sa sb a e. (sa -> sb) -> EffModel sa a e -> EffModel sb a e
-mapState a2b effmodel =
-  { state: a2b effmodel.state, effects: effmodel.effects }
-
--- | Map over the effectful actions of an `EffModel`.
-mapEffects :: forall s a b e. (a -> b) -> EffModel s a e -> EffModel s b e
-mapEffects action effmodel =
-  { state: effmodel.state, effects: map (map action) effmodel.effects }
+type App state action = B.App Html state action
 
 foreign import renderToDOM :: forall a eff. String -> Signal (Html a) -> Eff eff Unit
 

--- a/src/Pux/Base.js
+++ b/src/Pux/Base.js
@@ -1,0 +1,57 @@
+"use strict";
+
+// module Pux.Base
+
+var React = (typeof require === 'function' && require('react'))
+    || (typeof window === 'object' && window.React);
+
+// Copy of Pux.render to remove potential conversion of html into <div>{html}</div>
+exports.render = function (input, parentAction, html) {
+    function composeAction(parentAction, html) {
+        var childAction = html.props && html.props.puxParentAction;
+        var action = parentAction;
+        if (childAction) {
+            action = function (a) {
+                return parentAction(childAction(a));
+            };
+        }
+        return action;
+    }
+
+    function render(input, parentAction, html) {
+        var props = html.props
+        var newProps = {};
+
+        for (var key in props) {
+            if (key !== 'puxParentAction' && typeof props[key] === 'function') {
+                newProps[key] = props[key](input, parentAction);
+            }
+        }
+
+        var newChildren = React.Children.map(html.props.children, function (child) {
+            if (typeof child === 'string') {
+                return child;
+            } else {
+                return render(input, composeAction(parentAction, child), child);
+            }
+        });
+
+        return React.cloneElement(html, newProps, newChildren);
+    }
+
+    return render(input, composeAction(parentAction, html), html);
+};
+
+// Copy of Pux.Html.Elements.element, to generalise type
+exports.element = function (tagName, attrs, children) {
+    if (Array.isArray(children[0])) children = children[0];
+
+    var props = attrs.reduce(function (obj, attr) {
+        var key = attr[0];
+        var val = attr[1];
+        obj[key] = val;
+        return obj;
+    }, {});
+
+    return React.createElement.apply(React, [tagName, props].concat(children));
+};

--- a/src/Pux/Base.purs
+++ b/src/Pux/Base.purs
@@ -1,0 +1,142 @@
+module Pux.Base
+  ( App
+  , Config
+  , Update
+  , EffModel
+  , CoreEffects
+  , noEffects
+  , onlyEffects
+  , fromSimple
+  , mapState
+  , mapEffects
+  , start
+  , element
+  ) where
+
+import Control.Monad.Aff (Aff, launchAff, later)
+import Control.Monad.Aff.Unsafe (unsafeCoerceAff)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Class (liftEff)
+import Control.Monad.Eff.Exception (EXCEPTION)
+import Data.Foldable (foldl, sequence_)
+import Data.Function.Uncurried (Fn3, runFn3)
+import Data.List (List(Nil), singleton, (:), reverse, fromFoldable)
+import Data.Maybe (fromJust)
+import Partial.Unsafe (unsafePartial)
+import Prelude (Unit, ($), (<<<), map, pure)
+import Prelude as Prelude
+import Pux.Html.Elements (Attribute)
+import Signal (Signal, (~>), mergeMany, foldp, runSignal)
+import Signal.Channel (CHANNEL, Channel, channel, subscribe, send)
+
+-- | Start an application. The resulting html signal is fed into `renderToDOM`.
+-- |
+-- | ```purescript
+-- | main = do
+-- |   app <- start
+-- |     { update: update
+-- |     , view: view
+-- |     , initialState: initialState
+-- |     , inputs: [] }
+-- |
+-- |   renderToDOM "#app" app.html
+-- | ```
+start :: forall state action eff target.
+         Config state action eff target ->
+         Eff (CoreEffects eff) (App state action target)
+start config = do
+  actionChannel <- channel Nil
+  let actionSignal = subscribe actionChannel
+      input = unsafePartial $ fromJust $ mergeMany $
+        reverse (actionSignal : map (map singleton) (fromFoldable $ config.inputs))
+      foldState effModel action = config.update action effModel.state
+      foldActions actions effModel =
+        foldl foldState (noEffects effModel.state) actions
+      effModelSignal =
+        foldp foldActions (noEffects config.initialState) input
+      stateSignal = effModelSignal ~> _.state
+      htmlSignal = stateSignal ~> \state ->
+        (runFn3 render) (send actionChannel <<< singleton) (\a -> a) (config.view state)
+      mapAffect affect = launchAff $ unsafeCoerceAff do
+        action <- later affect
+        liftEff $ send actionChannel (singleton action)
+      effectsSignal = effModelSignal ~> map mapAffect <<< _.effects
+  runSignal $ effectsSignal ~> sequence_
+  pure $ { html: htmlSignal, state: stateSignal, actionChannel: actionChannel }
+  where bind = Prelude.bind
+
+foreign import render :: forall a eff target. Fn3 (a -> Eff eff Unit) (a -> a) (target a) (target a)
+
+-- | The configuration of an app consists of update and view functions along
+-- | with an initial state.
+-- |
+-- | The `update` and `view` functions describe how to step the state and view
+-- | the state.
+-- |
+-- | The `inputs` array is for any external signals you might need. These will
+-- | be merged into the app's input signal.
+type Config state action eff target =
+  { update :: Update state action eff
+  , view :: state -> target action
+  , initialState :: state
+  , inputs :: Array (Signal action)
+  }
+
+-- | The set of effects every Pux app needs to allow through when using `start`.
+-- | Extend this type with your own app's effects, for example:
+-- |
+-- | ```purescript
+-- | type AppEffects = (console :: CONSOLE, dom :: DOM)
+-- |
+-- | main :: State -> Eff (CoreEffects AppEffects) (App State Action)
+-- | main state = do
+-- |   -- ...
+-- | ```
+type CoreEffects eff = (channel :: CHANNEL, err :: EXCEPTION | eff)
+
+-- | An `App` consists of three signals:
+-- |
+-- | * `html` – A signal of `Html` representing the current view of your
+-- |   app. This should be fed into `renderToDOM`.
+-- |
+-- | * `state` – A signal representing the application's current state.
+type App state action target =
+  { html :: Signal (target action)
+  , state :: Signal state
+  , actionChannel :: Channel (List action)
+  }
+
+-- | Synonym for an update function that returns state and an array of
+-- | asynchronous effects that return an action.
+type Update state action eff = action -> state -> EffModel state action eff
+
+-- | `EffModel` is a container for state and a collection of asynchronous
+-- | effects which return an action.
+type EffModel state action eff =
+  { state :: state
+  , effects :: Array (Aff (CoreEffects eff) action) }
+
+-- | Create an `Update` function from a simple step function.
+fromSimple :: forall s a eff. (a -> s -> s) -> Update s a eff
+fromSimple update = \action state -> noEffects $ update action state
+
+-- | Create an `EffModel` with no effects from a given state.
+noEffects :: forall state action eff. state -> EffModel state action eff
+noEffects state = { state: state, effects: [] }
+
+onlyEffects :: forall state action eff.
+               state -> Array (Aff (CoreEffects eff) action) -> EffModel state action eff
+onlyEffects state effects = { state: state, effects: effects }
+
+-- | Map over the state of an `EffModel`.
+mapState :: forall sa sb a e. (sa -> sb) -> EffModel sa a e -> EffModel sb a e
+mapState a2b effmodel =
+  { state: a2b effmodel.state, effects: effmodel.effects }
+
+-- | Map over the effectful actions of an `EffModel`.
+mapEffects :: forall s a b e. (a -> b) -> EffModel s a e -> EffModel s b e
+mapEffects action effmodel =
+  { state: effmodel.state, effects: map (map action) effmodel.effects }
+
+foreign import element :: forall a target.
+                          Fn3 String (Array (Attribute a)) (Array (target a)) (target a)


### PR DESCRIPTION
As an experiment to use Pux with [react-blessed](https://github.com/Yomguithereal/react-blessed) and React Native,  I made a few changes to make Pux more general: `forall a. target a` instead of `Html a`. This allowed me to reuse most of Pux to implement `Screen a` and `Native a` as backends using the Pux architecture.

This PR is mostly a proof-of-concept, and I'd be grateful for any feedback. I don't feel that it *has* to be merged in it's current state. Some parts are a bit odd as I tried to to maintain backwards-compatibility in `Pux`, while providing the generic functionality in `Pux.Base`. I haven't included the RN and Blessed backends, I'll hopefully put them online in a different repository shortly, but the code is a bit of a mess (doesn't everyone say that? 😹).