### PR TITLE
Use CustomEvent

### DIFF
--- a/src/Pux/Router.js
+++ b/src/Pux/Router.js
@@ -24,7 +24,7 @@ exports.linkHandler = function (url) {
       ev.preventDefault();
       if (typeof window !== 'undefined') {
         window.history.pushState({}, document.title, url);
-        window.dispatchEvent(new Event('popstate'));
+        window.dispatchEvent(new CustomEvent('popstate'));
       }
     };
   }];
@@ -34,7 +34,7 @@ exports.navigateTo = function (url) {
   return function () {
     if (typeof window !== 'undefined') {
       window.history.pushState({}, document.title, url);
-      window.dispatchEvent(new Event('popstate'));
+      window.dispatchEvent(new CustomEvent('popstate'));
     }
   }
 };


### PR DESCRIPTION
As noted in https://github.com/alexmingoia/purescript-pux/issues/76, IE straight-up doesn't support `new Event`. It also doesn't support `new CustomEvent`. `new CustomEvent` seems to be the more full-featured and more recommended way of doing events like this.

> While a window.CustomEvent object exists, it cannot be called as a constructor. Instead of new CustomEvent(...), you must use e = document.createEvent('CustomEvent') and then e.initCustomEvent(...)
Source: [CanIUse: CustomEvent](http://caniuse.com/#search=CustomEvent)

Also, see "The old-fashioned way" in [MDN: Web/Guide/Events/Creating_and_triggering_events](https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events)

I recommend using "CustomEvent" and then adding a polyfill, like  [github.com/jonathantneal/EventListener](https://raw.githubusercontent.com/jonathantneal/EventListener/master/EventListener.js).

If not advising Pux-users to use the polyfill, then we have to do "the old-fashioned way", or do browser-detection and include the IE-supported way in this library.