### PR TITLE
Update navigation example in the Routing guide.

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -61,25 +61,22 @@ main = do
     }
 ```
 
-Everytime the location changes and the `PageView` event occurs, we can update
+Every time the location changes and the `PageView` event occurs, we can update
 our state with the current route, which includes any captured path or query
 parameters. `Navigate` is used to change the location in response to the user
 clicking a link, using the HTML5 History methods provided by purescript-dom.
 
 ```purescript
 foldp :: ∀ fx. Event -> State -> EffModel State Event (history :: HISTORY, dom :: DOM | fx)
+foldp (PageView route) st =
+  noEffects $ st { currentRoute = route }
 foldp (Navigate url ev) st =
-  { state: st
-  , effects: [
-      liftEff do
-        preventDefault ev
-        h <- history =<< window
-        pushState (toForeign {}) (DocumentTitle "") (URL url) h
-        pure Nothing
-    ]
-  }
-
-foldp (PageView route) st = noEffects $ st { currentRoute = route }
+  onlyEffects st [ liftEff do
+                     preventDefault ev
+                     h <- history =<< window
+                     pushState (toForeign {}) (DocumentTitle "") (URL url) h
+                     pure $ Just $ PageView (match url)
+                 ]
 ```
 
 Finally, we might want to create links to our routes and show different views


### PR DESCRIPTION
Update the example in the Routing guide so that we trigger a `PageView` event when navigation happens.

When you copied this example code before, this example only updated the location in the address bar (by modifying browser's history), but no visible change in the app was triggered. The updated example modifies the location in the address bar and triggers a `PageView` event so that the app can update itself accordingly.

I've re-ordered the two cases in `foldp` to reflect the order both events appear in the preceding section.