### PR TITLE
Upgrade to smolder 9

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "purescript-react": "^3.0.0",
     "purescript-globals": "^3.0.0",
     "purescript-dom": "^4.2.0",
-    "purescript-smolder": "^7.0.0",
+    "purescript-smolder": "^9.0.0",
     "purescript-css": "^3.0.0"
   },
   "devDependencies": {

--- a/src/Pux/DOM/HTML.purs
+++ b/src/Pux/DOM/HTML.purs
@@ -11,7 +11,7 @@ import CSS.Stylesheet (CSS)
 import Data.CatList (snoc)
 import Data.Function (($))
 import Data.Functor (map)
-import Data.Maybe (fromMaybe, Maybe(..))
+import Data.Maybe (fromMaybe)
 import Data.Monoid (mempty)
 import Data.Unit (unit)
 import Pux.DOM.Events (DOMEvent, mapEventHandler)
@@ -40,7 +40,7 @@ child f view = memoize $ \s -> mapEvent f (view s)
 -- | function every time the view is called.
 mapEvent :: ∀ a b. (a -> b) -> HTML a -> HTML b
 mapEvent f (Element n c a e r) =
-  Element n (map (mapEvent f) c) a (map (mapEventHandler f) e) (mapEvent f r)
+  Element n (mapEvent f c) a (map (mapEventHandler f) e) (mapEvent f r)
 mapEvent f (Content str rest) =
   Content str (mapEvent f rest)
 mapEvent f (Return a) =
@@ -57,7 +57,7 @@ memoize = memoize_ wrapper
   where
   -- | Wraps memoized vdom in a thunk element that stores the current state
   -- | out-of-band, which allows renderers to cache views by state.
-  wrapper s c = Element "thunk" (Just c) (snoc mempty (Attr "state" s)) mempty (Return unit)
+  wrapper s c = Element "thunk" c (snoc mempty (Attr "state" s)) mempty (Return unit)
 
 foreign import memoize_ :: ∀ st ev. (String -> HTML ev -> HTML ev) -> (st -> HTML ev) -> (st -> HTML ev)
 

--- a/src/Pux/Renderer/React.purs
+++ b/src/Pux/Renderer/React.purs
@@ -15,7 +15,7 @@ import Data.Array ((:))
 import Data.CatList (CatList)
 import Data.Function (($))
 import Data.Function.Uncurried (Fn4, runFn4)
-import Data.Functor ((<$>), map)
+import Data.Functor (map)
 import Data.List (List(..), singleton)
 import Data.Nullable (Nullable, toNullable)
 import Data.Maybe (Maybe(..))
@@ -109,10 +109,10 @@ foreign import reactAttr :: String -> ReactAttribute
 foreign import data ReactAttribute :: Type
 
 renderNodes :: ∀ e. (e -> ReactAttribute) -> Markup e -> Array ReactElement
-renderNodes input node@(Element n (Just (Return _)) a e r) =
+renderNodes input node@(Element n (Return _) a e r) =
   runFn4 reactElement node n (renderAttrs input a e) (toNullable Nothing) : renderNodes input r
 renderNodes input node@(Element n c a e r) =
-  runFn4 reactElement node n (renderAttrs input a e) (toNullable (renderNodes input <$> c)) : renderNodes input r
+  runFn4 reactElement node n (renderAttrs input a e) (toNullable (Just (renderNodes input c))) : renderNodes input r
 renderNodes input (Content t r) =
   reactText t : renderNodes input r
 renderNodes input (Return _) = []


### PR DESCRIPTION
From smolder 7 to 9, it looks like the second argument for the Element
constructor went from (Maybe (Markup e)) to (Markup e). I'm attempting
to get pux back into the psc-package package set which recently
upgraded to smolder 9, so this is necessary.