### PR TITLE
Fix crash when React event object is null

### DIFF
--- a/src/Pux/Renderer/React.js
+++ b/src/Pux/Renderer/React.js
@@ -111,7 +111,7 @@ exports.reactAttr = function (str) {
 exports.reactHandler = function (input) {
   return function (handler) {
     return function (ev) {
-      if (ev.nativeEvent === undefined) {
+      if (!ev || ev.nativeEvent === undefined) {
         input(handler(ev))();
       } else {
         input(handler(ev.nativeEvent))();


### PR DESCRIPTION
It seems some React components will send `null` as the event object (for example, [react-select][1]), and Pux will crash on these.

This PR simply adds a truthiness test to make sure the event object is not null or undefined before trying to access `nativeEvent`.

[1]: https://github.com/JedWatson/react-select