### PR TITLE
Update to use Smolder v10.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "purescript-react": "^3.0.0",
     "purescript-globals": "^3.0.0",
     "purescript-dom": "^4.2.0",
-    "purescript-smolder": "^9.0.0",
+    "purescript-smolder": "^10.1.0",
     "purescript-css": "^3.0.0"
   },
   "devDependencies": {

--- a/src/Pux/DOM/Events.purs
+++ b/src/Pux/DOM/Events.purs
@@ -1,7 +1,7 @@
 module Pux.DOM.Events where
 
 import DOM.Event.Types (Event)
-import Text.Smolder.Markup (EventHandler(..), EventHandlers, on)
+import Text.Smolder.Markup (EventHandlers, on)
 
 -- | Synonym for
 -- | [DOM.Event.Types.Event](https://pursuit.purescript.org/packages/purescript-dom/4.3.1/docs/DOM.Event.Types#t:Event)
@@ -10,14 +10,6 @@ type DOMEvent = Event
 
 -- | Return `event.target.value` if it exists, or an empty string if not.
 foreign import targetValue :: DOMEvent -> String
-
--- | Map event handler that returns event type `a` to event handler that returns
--- | event type `b`.
-mapEventHandler :: ∀ a b
-                   .  (a -> b)
-                   -> EventHandler (DOMEvent -> a)
-                   -> EventHandler (DOMEvent -> b)
-mapEventHandler f (EventHandler s a) = EventHandler s (\e -> f (a e))
 
 onCopy :: ∀ ev. (DOMEvent -> ev) -> EventHandlers (DOMEvent -> ev)
 onCopy = on "onCopy"

--- a/src/Pux/Renderer/React.js
+++ b/src/Pux/Renderer/React.js
@@ -132,7 +132,7 @@ var PureComponent = React.createClass({
   }
 });
 
-exports.reactElement = function (node, name, attrs, children) {
+exports.reactElement = function (name, attrs, children) {
   // convert smolder attribute names to react attribute names
   var reactAttrs = {};
   for (var key in attrs) {


### PR DESCRIPTION
I just updated Smolder to use the stack safe `purescript-free` free monad, after prompting by #138, and I figured I'd make you a PR to update Pux's React renderer accordingly.

I'm not sure if my patch is either sound or stack safe, as I haven't tested it beyond making sure `pux-starter-app` still runs, but at least it doesn't seem to have made things worse.