### PR TITLE
create-react-class instead of React.createClass

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "bower": "^1.8.0",
+    "create-react-class": "^15.6.0",
     "pulp": "^11.0.0",
     "purescript": "^0.11.4"
   },

--- a/src/Pux/Renderer/React.js
+++ b/src/Pux/Renderer/React.js
@@ -2,6 +2,8 @@
 
 // module Pux.Renderer.React
 
+const createReactClass = require('create-react-class');
+
 var React = (typeof require === 'function' && require('react'))
          || (typeof window === 'object' && window.React);
 
@@ -57,7 +59,7 @@ exports.toReact = function (vdomSignal) {
     }
   }
 
-  return React.createClass({
+  return createReactClass({
     componentWillMount: function () {
       var ctx = this;
       var subscribed = false;
@@ -122,7 +124,7 @@ exports.reactHandler = function (input) {
 
 // Wraps memoized views in a component class which only re-renders if the state
 // has changed.
-var PureComponent = React.createClass({
+var PureComponent = createReactClass({
   shouldComponentUpdate: function (nextProps) {
     if (nextProps.state.st === undefined) return true;
     return nextProps.state.st !== this.props.state.st;


### PR DESCRIPTION
React.createClass is deprecated so purescript-pux applications get deprecation warning. 

The create-react-class package allows the code to use a nearly identical API and is the recommended solution on the [React site](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.createclass).

This request adds the create-react-class package dependency and uses it in the React renderer FFI code.
