### PR TITLE
Add matcher to ignore the rest of the path.

### DIFF
--- a/src/Pux/Router.purs
+++ b/src/Pux/Router.purs
@@ -105,6 +105,15 @@ any = Match $ \r ->
     Cons p ps -> Just $ Tuple ps unit
     _ -> Nothing
 
+manyAny :: Match Unit
+manyAny = Match $ manyAny_
+  where
+    manyAny_ r =
+        case r of
+            Cons (Query map) ps -> Just $ Tuple (Cons (Query map) Nil) unit
+            Cons (Path p) ps -> manyAny_ ps
+            _ -> Nothing
+
 instance matchFunctor :: Functor Match where
   map f (Match r2t) = Match $ \r ->
     maybe Nothing (\t -> Just $ Tuple (fst t) (f (snd t))) $ r2t r


### PR DESCRIPTION
We have a Pux application that can be embedded in any page. It has a backend component that is embedded in an admin area like <site>/admin/page.

The application itself only uses the query params as the php backend handles the whole url.

So I have added a function that matches any number of url segments, to avoid having to repeat myself.

As an aside for posterity, I came up with this while debugging behaviour where having a trailing slash before the query string was causing my route matching to fail. This is because `someurl/page/?param=something` and `someurl/page?param=something` are parsed into 

`(Cons Path "someurl" (Cons Path "" (Cons Query (M.Map "param" "something") Nil ) ) )`

and

`(Cons Path "someurl" (Cons Query (M.Map "param" "something") Nil) )`

respectively, due to the behaviour of `S.split (S.Pattern "/")` in `routeFromUrl`.