### PR TITLE
bower ignore .babelrc

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,8 @@
   "license": "Apache-2.0",
   "ignore": [
     "node_modules",
-    "bower_components"
+    "bower_components",
+    ".babelrc"
   ],
   "keywords": [
     "purescript",


### PR DESCRIPTION
Not sure if this is actually the right thing to do but not having `.babelrc` in the local pux library downloaded by bower fixed a problem I had with version 11:

- when attempting `webpack-dev-server`, the build failed because preact-compat (and preact ultimately) could not be found
- even when I added those with `npm i preact-compat preact` I would get a runtime error on the page, claiming that _Can only update a mounted or mounting component. This usually means you called forceUpdate() on an unmounted component_
- using `webpack` to simply build the static page had no problems whatsoever before or after removing pux's `.babelrc`.

