### PR TITLE
Add React Interop to sidebar

### DIFF
--- a/website/src/App/View/Sidebar.purs
+++ b/website/src/App/View/Sidebar.purs
@@ -51,6 +51,7 @@ view st = do
       li $ navLink st "/docs/forms" "Forms"
       li $ navLink st "/docs/routing" "Routing"
       li $ navLink st "/docs/css" "CSS"
+      li $ navLink st "/docs/react-interop" "React Interop"
 
     ul do
       li $ navLink st "https://pursuit.purescript.org/packages/purescript-pux" "API Reference"


### PR DESCRIPTION
I only happened to notice the react-interop page because it was linked at the end of the CSS page.