### PR TITLE
Add a utility function to sample hash URL

### DIFF
--- a/src/Pux/DOM/History.purs
+++ b/src/Pux/DOM/History.purs
@@ -1,4 +1,4 @@
-module Pux.DOM.History (sampleURL) where
+module Pux.DOM.History (sampleURL, sampleHashURL) where
 
 import Control.Applicative (pure)
 import Control.Bind (bind)
@@ -6,8 +6,8 @@ import Control.Monad.Eff (Eff)
 import DOM (DOM)
 import DOM.Event.EventTarget (addEventListener, eventListener)
 import DOM.Event.Types (EventType(..))
-import DOM.HTML.Location (pathname, search)
-import DOM.HTML.Types (HISTORY, Window, windowToEventTarget)
+import DOM.HTML.Location (pathname, search, hash)
+import DOM.HTML.Types (HISTORY, Window, Location, windowToEventTarget)
 import DOM.HTML.Window (location)
 import Data.Semigroup ((<>))
 import Prelude (discard)
@@ -17,14 +17,20 @@ import Signal.Channel (CHANNEL, channel, send, subscribe)
 -- | Returns a signal containing the current window.location pathname and search query,
 -- | which is updated on every "popstate" event.
 sampleURL :: ∀ eff. Window -> Eff (channel :: CHANNEL, history :: HISTORY, dom :: DOM | eff) (Signal String)
-sampleURL win = do
+sampleURL = sampleLocationWith pathname
+
+sampleHashURL :: ∀ eff. Window -> Eff (channel :: CHANNEL, dom :: DOM | eff) (Signal String)
+sampleHashURL = sampleLocationWith hash
+
+sampleLocationWith :: ∀ eff. (Location -> Eff (channel :: CHANNEL, dom :: DOM| eff) String) -> Window -> Eff (channel :: CHANNEL, dom :: DOM | eff) (Signal String)
+sampleLocationWith f win = do
   loc <- location win
-  path <- pathname loc
+  path <- f loc
   search <- search loc
   chan <- channel (path <> search)
 
   let listener = eventListener \ev -> do
-        url <- pathname loc
+        url <- f loc
         send chan url
 
   addEventListener (EventType "popstate") listener false (windowToEventTarget win)


### PR DESCRIPTION
This PR allow to use Pux router with hash urls which wasn't possible before because `pathname` was used.
Let me know if you have remarks or comments on something I may missed :)