### PR TITLE
Define lifted log because of new Aff api

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -54,13 +54,15 @@ Effectful computations returned by foldp are asynchronous and handled by the
 computations may return new events which are again handled by foldp.
 
 For example, to log to the console when an event occurs we can use
-purescript-aff's `log`:
+a lifted `log`:
 
 ```purescript
+liftedLog = liftEff <<< log
+
 foldp :: Event -> State -> EffModel State Event (console :: CONSOLE)
 foldp Increment count =
   { state: count + 1
-  , effects: [ log "increment" *> pure Nothing ]
+  , effects: [ liftedLog "increment" *> pure Nothing ]
   }
 ```
 


### PR DESCRIPTION
`purescript-aff` [used to have its own `log`](https://github.com/slamdata/purescript-aff/blob/3457df9993a78e408ed56f0bb619941911d375d0/src/Control/Monad/Aff/Console.purs#L20), but as far as I can tell, it no longer does.

Please feel free to suggest alternative ways to improve the docs; I just know that this confused me since I'm very new to Purescript, I couldn't import the `log` function as described.